### PR TITLE
Down CLI command

### DIFF
--- a/cli/commands/down.go
+++ b/cli/commands/down.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"errors"
+	"log"
+
+	"github.com/CityOfZion/neo-local/cli/services"
+	"github.com/urfave/cli"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"golang.org/x/net/context"
+)
+
+type (
+	// Down is the CLI command for stopping and removing containers within the
+	// neo-local stack.
+	Down struct{}
+)
+
+// NewDown creates a new Down.
+func NewDown() Down {
+	return Down{}
+}
+
+// ToCommand generates the CLI command struct.
+func (d Down) ToCommand() cli.Command {
+	return cli.Command{
+		Action:  d.action(),
+		Aliases: []string{"destroy"},
+		Flags:   d.flags(),
+		Name:    "down",
+		Usage:   "Stop and destroy all containers",
+	}
+}
+
+func (d Down) action() func(c *cli.Context) error {
+	return func(c *cli.Context) error {
+		ctx := context.Background()
+		cli, err := client.NewEnvClient()
+		if err != nil {
+			return errors.New("Unable to create Docker client")
+		}
+
+		ok := services.CheckDockerRunning(ctx, cli)
+		if !ok {
+			return errors.New("Docker is not running")
+		}
+
+		log.Println("Removing containers")
+
+		containerReferences, err := services.FetchContainerReferences(ctx, cli)
+		if err != nil {
+			return err
+		}
+
+		options := types.ContainerRemoveOptions{
+			Force: true,
+		}
+
+		for containerName, containerID := range containerReferences {
+			if containerID == "" {
+				log.Printf("'%s' container already removed", containerName)
+				continue
+			}
+
+			log.Printf("'%s' container removed (%s)", containerName, containerID[:10])
+			if err := cli.ContainerRemove(ctx, containerID, options); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+func (d Down) flags() []cli.Flag {
+	return []cli.Flag{}
+}

--- a/cli/commands/index.go
+++ b/cli/commands/index.go
@@ -7,10 +7,12 @@ import (
 // GenerateCommandsIndex creates a slice of all the commands that are within
 // the CLI.
 func GenerateCommandsIndex() []cli.Command {
+	down := NewDown()
 	start := NewStart()
 	status := NewStatus()
 
 	return []cli.Command{
+		down.ToCommand(),
 		start.ToCommand(),
 		status.ToCommand(),
 	}

--- a/cli/commands/status.go
+++ b/cli/commands/status.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"strings"
 
@@ -59,8 +58,7 @@ func (s Status) action() func(c *cli.Context) error {
 		for _, container := range runningContainers {
 			containerName := ""
 			for _, name := range container.Names {
-				if strings.Contains(name, "coz_neo-local_") { // TODO: this string should be a const.
-					fmt.Println(name)
+				if strings.Contains(name, stack.ContainerNamePrefix) {
 					containerName = name
 					break
 				}

--- a/cli/stack/service.go
+++ b/cli/stack/service.go
@@ -6,6 +6,11 @@ import (
 	"github.com/docker/docker/api/types/container"
 )
 
+const (
+	// ContainerNamePrefix is the prefix added to all neo-local containers.
+	ContainerNamePrefix = "coz_neo-local_"
+)
+
 type (
 	// Service defines a Docker container to run within the stack.
 	Service struct {
@@ -26,7 +31,7 @@ func (s Service) Config() *container.Config {
 
 // ContainerName is the Docker container name.
 func (s Service) ContainerName() string {
-	return fmt.Sprintf("coz_neo-local_%s", s.Image)
+	return fmt.Sprintf("%s%s", ContainerNamePrefix, s.Image)
 }
 
 // ImageName is the full Docker image name for the service, including the tag.

--- a/cli/stack/services.go
+++ b/cli/stack/services.go
@@ -7,3 +7,14 @@ func Services() []Service {
 		NewPostgres(),
 	}
 }
+
+// ServiceContainerNames returns all of the service container names in an array.
+func ServiceContainerNames() []string {
+	containerNames := []string{}
+
+	for _, service := range Services() {
+		containerNames = append(containerNames, service.ContainerName())
+	}
+
+	return containerNames
+}


### PR DESCRIPTION
Fixes #74 🌮 

## Problem

The CLI has no way of removing containers that it has started.

## Solution

Add a new top level command to the CLI that stops and removes all containers.

<img width="626" alt="image" src="https://user-images.githubusercontent.com/2796074/47877350-975d0200-de13-11e8-9efb-5c46ac6f15c3.png">

## Checklist

- [x] I have ran the tests locally.
- [x] I branched off of the `develop` branch and not `master`.
- [x] I did not change the `VERSION` file.
