### PR TITLE
HealthCheck monitoring for Container/Service NEO-SCAN

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,6 @@ services:
     - notifications-server
     environment:
       NEO_NOTIFICATIONS_SERVER: "http://${NOTIFICATIONS_SERVER}:8080/v1"
-
       NEO_SEEDS: "http://neo-cli-privatenet-1:30333;http://neo-cli-privatenet-2:30334;http://neo-cli-privatenet-3:30335;http://neo-cli-privatenet-4:30336"
       PORT: 4000
       DB_HOSTNAME: postgres
@@ -91,7 +90,16 @@ services:
       - "neo-cli-privatenet-3:30335"
       - "neo-cli-privatenet-4:30336"
     ports:
-    - "4000:4000"
+      - "4000:4000"
+    restart: always
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 6<>/dev/tcp/127.0.0.1/4000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    labels:
+      autoheal: "true"
 
   neo-scan-sync:
     container_name: neo-scan-sync
@@ -129,7 +137,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - "./notifications-server.config.json:/neo-python/custom-config.json"
+      - "./notifications-server/notifications-server.config.json:/neo-python/custom-config.json"
 
   postgres:
     container_name: postgres
@@ -140,3 +148,14 @@ services:
     expose:
       - 5432
     image: library/postgres:10.5
+
+  autoheal:
+    restart: always
+    image: willfarrell/autoheal
+    environment:
+      - AUTOHEAL_CONTAINER_LABEL=all
+      - AUTOHEAL_CONTAINER_LABEL=autoheal
+      - AUTOHEAL_INTERVAL=5
+      - DOCKER_SOCK=/var/run/docker.sock
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/scripts/ping.sh
+++ b/scripts/ping.sh
@@ -1,9 +1,10 @@
 #! /bin/bash
 # Script to check and wait until the NeoScan service is operational. 
 
-until $(curl --output /dev/null --silent --head --fail http://localhost:4000); do
+while [ "$(docker inspect --format '{{json .State.Health.Status }}' neo-scan-api)" != "\"healthy\"" ]
+  do
     printf '.'
     sleep 3
-done
+  done
 
 printf "\n"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -2,7 +2,7 @@
 # Script used within the integration tests to check that all the services are operational.
 
 CURRENT_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-EXPECTED_NUMBER_OF_SERVICES=10
+EXPECTED_NUMBER_OF_SERVICES=11
 
 NUMBER_OF_RUNNING_SERVICES=$(docker-compose ps | grep "Up" | wc -l)
 


### PR DESCRIPTION
## Problem

Solving https://github.com/CityOfZion/neo-local/issues/126

## Solution

- Adding restart always parameters to neo-scan-api to take actions in case container exits.
- Adding also a new container that will monitor/control service status and if it's not Healthy, restart the container.
This will help solve issues when neo-scan was hanging at start and trace the path to have correct healthcheck on other containers in the future.

## Checklist

- [x] I have ran the tests locally.
- [x] I branched off of the `develop` branch and not `master`.
- [x] I did not change the `VERSION` file.
