### PR TITLE
Add MIN_BLOCK to .env

### DIFF
--- a/.env
+++ b/.env
@@ -16,3 +16,8 @@ NODE4_NEO_CLI_VERSION=2.9.3
 # Supported versions are: _genesis, _4kBlocks
 # _genesis means starting from block zero and _4kBlocks starts with 4000 blocks
 BOOTSTRAP=_4kBlocks
+
+# neo-local-faucet
+# Minimum amount of blocks that need to have been minted between request from
+# any given address
+MIN_BLOCK=2500


### PR DESCRIPTION
## Problem
neo-local-faucet service fails to process request from any wallet with default env variable BOOTSTRAP=_4kBlocks. Chain height of < 5000 breaks service and cause infinite loop in container.
...

## Solution
Add MIN_BLOCK=2500 to .env file
...

## Checklist

- [x] I have run the tests locally.
- [x] I branched off of the `develop` branch and not `master`.
- [x] I did not change the `VERSION` file.
